### PR TITLE
Reconciling TBB updates

### DIFF
--- a/protobufs/derecmessage.proto
+++ b/protobufs/derecmessage.proto
@@ -4,8 +4,8 @@ import "pair.proto";
 import "unpair.proto";
 import "storeshare.proto";
 import "verify.proto";
-import "secretidsversions.proto";
 import "getshare.proto";
+import "secretidsversions.proto";
 import "messagingerror.proto";
 
 package derec.message;
@@ -31,8 +31,8 @@ message DeRecMessage {
   /*
    * DeRec protocol version number
    */
-  int32 versionMajor = 1;
-  int32 versionMinor = 2;
+  int32 protocolVersionMajor = 1;
+  int32 protocolVersionMinor = 2;
 
   /*
    * SHA-384 hash of sender public key (used to identify the sender and key)
@@ -46,9 +46,9 @@ message DeRecMessage {
   bytes receiver = 4;
 
   /*
-   * secret ID (64-bit random number chosen by sharer at initial pairing)
+   * secret ID (128-bit random number chosen by sharer at initial pairing)
    */
-  int64 secretId = 5;
+  bytes secretId = 5;
 
   /*
    * UTC timestamp for when the sender created this message

--- a/protobufs/storeshare.proto
+++ b/protobufs/storeshare.proto
@@ -97,9 +97,11 @@ message DeRecShare {
 
   /*
    * sharer-assigned identifier for the secret;
-   * this is an opaque 64-bit value
+   * this is an opaque 128-bit value also
+   * present in message header. Size chosen to
+   * accommodate UUID if sharer chooses
    */
-  int64 secretId = 4;
+  bytes secretId = 4;
 
   /*
    * version number for the share;
@@ -107,7 +109,7 @@ message DeRecShare {
    * StoreShareRequestMessage with a version less
    * than or equal to the last seen version
    */
-  int64 version = 5;
+  int32 version = 5;
 }
 
 /*


### PR DESCRIPTION
Attempt to reconcile changes with TBB's protobufs.
Changes made:
- **`derecmessage.proto`**
	- renaming of variables `versionMajor` and `versionMinor` to `protocolVersionMajor` and `protocolVersionMinor`
	- Changing `secretId` to 128 bits, and changing its type to `bytes` accordingly
- **`storeshare.proto`**
	- Changing `secretId` to 128 bits, and changing its type to `bytes` accordingly
	- Changing type of share version number `version` to `int32` instead of `int64`

Changes not pulled from TBB:
- **`contact.proto`**
	- Did not previously exist in TBB repo
- **`messagingerror.proto`**
	- Did not previously exist in TBB repo
- **`storeshare.proto`**
	- Cryptographic keys are now PEM encoded, and their type is changed to `string`.
	- `HelperSpecificInfo` is kept

