### PR TITLE
Protobuf reconciliation

### DIFF
--- a/protobufs/derecmessage.proto
+++ b/protobufs/derecmessage.proto
@@ -46,9 +46,9 @@ message DeRecMessage {
   bytes receiver = 4;
 
   /*
-   * secret ID (128-bit random number chosen by sharer at initial pairing)
+   * secret ID (64-bit random number chosen by sharer at initial pairing)
    */
-  bytes secretId = 5;
+  int64 secretId = 5;
 
   /*
    * UTC timestamp for when the sender created this message

--- a/protobufs/getshare.proto
+++ b/protobufs/getshare.proto
@@ -10,7 +10,7 @@ message GetShareRequestMessage {
   int64 secretId = 1;
 
   /* the share version for the requested share */
-  int64 shareVersion = 2;
+  int32 shareVersion = 2;
 }
 
 /*

--- a/protobufs/secretidsversions.proto
+++ b/protobufs/secretidsversions.proto
@@ -40,7 +40,7 @@ message GetSecretIdsVersionsResponseMessage {
    */
   message VersionList {
     int64 secretId = 1;
-    repeated int64 versions = 2;
+    repeated int32 versions = 2;
   }
 }
 

--- a/protobufs/storeshare.proto
+++ b/protobufs/storeshare.proto
@@ -31,7 +31,7 @@ message StoreShareRequestMessage {
   * All versions that the helper must retain (including this new one).
   * The helper should delete all other versions outside this list.
   */
-  repeated int64 keepList = 3;
+  repeated int32 keepList = 3;
 }
 
 /*
@@ -97,11 +97,9 @@ message DeRecShare {
 
   /*
    * sharer-assigned identifier for the secret;
-   * this is an opaque 128-bit value also
-   * present in message header. Size chosen to
-   * accommodate UUID if sharer chooses
+   * this is an opaque 64-bit value
    */
-  bytes secretId = 4;
+  int64 secretId = 4;
 
   /*
    * version number for the share;
@@ -162,5 +160,5 @@ message StoreShareResponseMessage {
   /*
    * version number from the share message
    */
-  int64 version = 2;
+  int32 version = 2;
 }

--- a/protobufs/verify.proto
+++ b/protobufs/verify.proto
@@ -13,7 +13,7 @@ message VerifyShareRequestMessage {
   /*
    * which share version is being verified?
    */
-  int64 version = 1;
+  int32 version = 1;
 
   /*
    * 256-bit nonce that serves as the challenge.
@@ -30,7 +30,7 @@ message VerifyShareResponseMessage {
   /*
    * which version is the response for?
    */
-  int64 version = 2;
+  int32 version = 2;
 
   /**
     * 256-bit nonce that was used in the challenge


### PR DESCRIPTION
Attempt to reconcile changes with TBB's protobufs.  

**Changes made:**
 - Changing type of secretId to int64 across all files
 - Changing type of share version number version to int32 instead of int64 across all files 
 - derecmessage.proto: renaming of variables versionMajor and
   versionMinor to protocolVersionMajor and protocolVersionMinor

**Changes not pulled from TBB's version:**
-   contact.proto
	-   Did not previously exist in TBB repo
-   messagingerror.proto
	-   Did not previously exist in TBB repo
-   storeshare.proto
	-   Cryptographic keys are now PEM encoded, and their type is changed to string.
	-   HelperSpecificInfo is kept